### PR TITLE
debian: Move conf files to /usr/lib

### DIFF
--- a/debian/cutie-shell-config-convergence.install
+++ b/debian/cutie-shell-config-convergence.install
@@ -1,1 +1,1 @@
-cutie-shell.service.d/20-convergence.conf etc/systemd/system/cutie-shell.service.d/
+cutie-shell.service.d/20-convergence.conf usr/lib/systemd/system/cutie-shell.service.d/

--- a/debian/cutie-shell-config-convergence.maintscript
+++ b/debian/cutie-shell-config-convergence.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/systemd/system/cutie-shell.service.d/20-convergence.conf 0.0.0+git20231212092431.1535010.droidian~

--- a/debian/cutie-shell-config-desktop.install
+++ b/debian/cutie-shell-config-desktop.install
@@ -1,1 +1,1 @@
-cutie-shell.service.d/10-desktop.conf etc/systemd/system/cutie-shell.service.d/
+cutie-shell.service.d/10-desktop.conf usr/lib/systemd/system/cutie-shell.service.d/

--- a/debian/cutie-shell-config-desktop.maintscript
+++ b/debian/cutie-shell-config-desktop.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/systemd/system/cutie-shell.service.d/10-desktop.conf 0.0.0+git20231212092431.1535010.droidian~

--- a/debian/cutie-shell-config-hybris.install
+++ b/debian/cutie-shell-config-hybris.install
@@ -1,2 +1,2 @@
-android-service@hwcomposer.service.d/20-cutie.conf etc/systemd/system/android-service@hwcomposer.service.d/
-cutie-shell.service.d/30-hybris.conf etc/systemd/system/cutie-shell.service.d/
+android-service@hwcomposer.service.d/20-cutie.conf usr/lib/systemd/system/android-service@hwcomposer.service.d/
+cutie-shell.service.d/30-hybris.conf usr/lib/systemd/system/cutie-shell.service.d/

--- a/debian/cutie-shell-config-hybris.maintscript
+++ b/debian/cutie-shell-config-hybris.maintscript
@@ -1,0 +1,2 @@
+rm_conffile /etc/systemd/system/cutie-shell.service.d/30-hybris.conf 0.0.0+git20231212092431.1535010.droidian~
+rm_conffile /etc/systemd/system/android-service@hwcomposer.service.d/20-cutie.conf 0.0.0+git20231212092431.1535010.droidian~

--- a/debian/cutie-shell-config-mobile.install
+++ b/debian/cutie-shell-config-mobile.install
@@ -1,1 +1,1 @@
-cutie-shell.service.d/10-mobile.conf etc/systemd/system/cutie-shell.service.d/
+cutie-shell.service.d/10-mobile.conf usr/lib/systemd/system/cutie-shell.service.d/

--- a/debian/cutie-shell-config-mobile.maintscript
+++ b/debian/cutie-shell-config-mobile.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/systemd/system/cutie-shell.service.d/10-mobile.conf 0.0.0+git20231212092431.1535010.droidian~

--- a/debian/cutie-shell-config.install
+++ b/debian/cutie-shell-config.install
@@ -1,1 +1,1 @@
-logind.conf.d/10-cutie.conf etc/systemd/logind.conf.d/
+logind.conf.d/10-cutie.conf usr/lib/systemd/logind.conf.d/

--- a/debian/cutie-shell-config.maintscript
+++ b/debian/cutie-shell-config.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/systemd/logind.conf.d/10-cutie.conf 0.0.0+git20231212092431.1535010.droidian~


### PR DESCRIPTION
debhelper assumes everything in /etc is a conf file. This means they won't be removed on removal (only on purge) and they won't be upgraded/installed if edited/removed manually.

For example, this is a problem if user wants to swap their installation from phosh to cutie. In this scenario, the phosh conf for `android-service@hwcomposer.service` still remains on the system and prevents cutie from starting: "Could not find phosh.service"

Therefore, we should install these files in /usr/lib (systemd still reads from there).

**Related:** https://github.com/droidian/phosh-config-hwcomposer/pull/3